### PR TITLE
Fix: Typo in tests

### DIFF
--- a/src/test/scala/fpcourse/GetSpec.scala
+++ b/src/test/scala/fpcourse/GetSpec.scala
@@ -21,7 +21,7 @@ class GetSpec extends AnyFunSuite with Matchers with Configuration with FunSuite
 
   test("getIntLE fails on insufficient input") {
     val bytes = List[Byte](3, 1, 2)
-    Get.getIntBE.run(bytes) shouldBe(Left("Insufficient input"))
+    Get.getIntLE.run(bytes) shouldBe(Left("Insufficient input"))
   }
 
   test("getIntLE should read an int in little endian order") {


### PR DESCRIPTION
## What does this change?
This change fixes a typo in the tests, to be consistent with the test's description.

## How can success be measured?
The tests run correctly.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/20479781/173909777-c243ef56-3788-42a0-a402-181e1d8160bd.png)

## Who should look at this?
@leusgalvan 


## Tested?
- [x] locally